### PR TITLE
Does not include aggregates when dumping schema (#34)

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -17,7 +17,10 @@ module Fx
               ON pn.oid = pp.pronamespace
           LEFT JOIN pg_depend pd
               ON pd.objid = pp.oid AND pd.deptype = 'e'
+          LEFT JOIN pg_aggregate pa
+              ON pa.aggfnoid = pp.oid
           WHERE pn.nspname = 'public' AND pd.objid IS NULL
+              AND pa.aggfnoid IS NULL
           ORDER BY pp.oid;
         EOS
 

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -19,4 +19,34 @@ describe Fx::SchemaDumper::Function, :db do
     expect(output).to include "create_function :test, sql_definition: <<-SQL"
     expect(output).to include "RETURN 'test';"
   end
+
+  it "does not dump a create_function for aggregates in the database" do
+    sql_definition = <<-EOS
+      CREATE OR REPLACE FUNCTION test(text, text)
+      RETURNS text AS $$
+      BEGIN
+          RETURN 'test';
+      END;
+      $$ LANGUAGE plpgsql;
+    EOS
+
+    aggregate_sql_definition = <<-EOS
+      CREATE AGGREGATE aggregate_test(text)
+      (
+          sfunc = test,
+          stype = text
+      );
+    EOS
+
+    connection.create_function :test, sql_definition: sql_definition
+    connection.execute aggregate_sql_definition
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+
+    output = stream.string
+    expect(output).to include "create_function :test, sql_definition: <<-SQL"
+    expect(output).to include "RETURN 'test';"
+    expect(output).not_to include "aggregate_test"
+  end
 end


### PR DESCRIPTION
Calling `pg_get_functiondef(some_oid)` on aggregates fails. Assuming
this gem is not meant to support aggregate functions, aggregate functions
are now excluded via omitting them from the query that pulls function
definitions from PG. This is achieved by checking for the function's
presence in table `pg_aggregate`.

`pg_aggregate` is present in all officially supported PG versions ( >= 9.4 ).